### PR TITLE
Update recent5me.js

### DIFF
--- a/cmd/recent5me.js
+++ b/cmd/recent5me.js
@@ -18,15 +18,14 @@ function modread(input) {
 function rankEmote(input) {
 	if (!input) return;
 	switch (input) {
-		case 'A': return '611559473236148265';
-		case 'B': return '611559473169039413';
-		case 'C': return '611559473328422942';
-		case 'D': return '611559473122639884';
-		case 'S': return '611559473294606336';
-		case 'X': return '611559473492000769';
-		case 'SH': return '611559473361846274';
-		case 'XH': return '611559473479155713';
-		default : return;
+		case 'A': return '555772511628034061';
+		case 'B': return '555772511753601037';
+		case 'C': return '555772511577702460';
+		case 'D': return '555772512026361862';
+		case 'S': return '555772511812321320';
+		case 'X': return '555772513460944931';
+		case 'SH': return '555772511741018142';
+		case 'XH': return '555772511997132830';
 	}
 }
 

--- a/cmd/recent5me.js
+++ b/cmd/recent5me.js
@@ -1,5 +1,4 @@
 var http = require('http');
-var mongodb = require('mongodb');
 require("dotenv").config();
 var droidapikey = process.env.DROID_API_KEY;
 
@@ -19,14 +18,14 @@ function modread(input) {
 function rankEmote(input) {
 	if (!input) return;
 	switch (input) {
-		case 'A': return '555772511628034061';
-		case 'B': return '555772511753601037';
-		case 'C': return '555772511577702460';
-		case 'D': return '555772512026361862';
-		case 'S': return '555772511812321320';
-		case 'X': return '555772513460944931';
-		case 'SH': return '555772511741018142';
-		case 'XH': return '555772511997132830';
+		case 'A': return '611559473236148265';
+		case 'B': return '611559473169039413';
+		case 'C': return '611559473328422942';
+		case 'D': return '611559473122639884';
+		case 'S': return '611559473294606336';
+		case 'X': return '611559473492000769';
+		case 'SH': return '611559473361846274';
+		case 'XH': return '611559473479155713';
 		default : return;
 	}
 }
@@ -34,10 +33,6 @@ function rankEmote(input) {
 module.exports.run = (client, message, args, maindb) => {
 	let ufind = message.author.id;
 	let page = 1;
-	/*Allows dynamic command format
-        If first argument is given and it is an integer with a value more than 10, it
-        treats the argument as user ID. Similarly, if it's a mention,
-        it will be treated as user ID as well.*/
 	if (args[0]) {
 		if (isNaN(args[0]) || parseInt(args[0]) > 10) ufind = args[0];
 		else if (parseInt(args[0]) <= 0) page = 1;
@@ -46,8 +41,6 @@ module.exports.run = (client, message, args, maindb) => {
 		ufind = ufind.replace('<@', '');
 		ufind = ufind.replace('>', '');
 	}
-	/*The second argument will override previous assigned page if
-	it was given and the first statement was assigned as page*/
 	if (args[1]) {
 		if (isNaN(args[1]) || parseInt(args[1]) > 10 || parseInt(args[1]) <= 0) page = 1;
 		else page = parseInt(args[1]);
@@ -101,7 +94,7 @@ module.exports.run = (client, message, args, maindb) => {
 						"color": 8102199,
 						"footer": {
 							"icon_url": "https://image.frl/p/yaa1nf94dho5f962.jpg",
-							"text": "Elaina owo"
+							"text": "Elaina owo by -Nero Yuki-"
 						},
 						"fields": entries
 					};

--- a/cmd/recent5me.js
+++ b/cmd/recent5me.js
@@ -5,13 +5,13 @@ var droidapikey = process.env.DROID_API_KEY;
 
 function modread(input) {
 	var res = '';
-	if (input.includes('n')) res += 'NF'
-	if (input.includes('h')) res += 'HD'
-	if (input.includes('r')) res += 'HR'
-	if (input.includes('e')) res += 'EZ'
-	if (input.includes('t')) res += 'HT'
-	if (input.includes('c')) res += 'NC'
-	if (input.includes('d')) res += 'DT'
+	if (input.includes('n')) res += 'NF';
+	if (input.includes('h')) res += 'HD';
+	if (input.includes('r')) res += 'HR';
+	if (input.includes('e')) res += 'EZ';
+	if (input.includes('t')) res += 'HT';
+	if (input.includes('c')) res += 'NC';
+	if (input.includes('d')) res += 'DT';
 	if (res) res = '+' + res;
 	return res;
 }
@@ -32,24 +32,34 @@ function rankEmote(input) {
 }
 
 module.exports.run = (client, message, args, maindb) => {
+	let page = 1;
+	if (args[0]) page = parseInt(args[0]); //First argument will be page
+	if (isNaN(args[0]) || page <= 0 || page > 10) page = 1; //Detect out-of-range page input
 	let ufind = message.author.id;
+	
+	/*Allows dynamic command format
+	If first argument is an integer with a value more than 10, it
+	treats the argument as user ID. Similarly, if it's a mention,
+	it will be treated as user ID as well.*/
 	if (args[0]) {
-		ufind = args[0];
-		ufind = ufind.replace('<@!','');
-		ufind = ufind.replace('<@','');
-		ufind = ufind.replace('>','');
+		if (isNaN(args[0]) || parseInt(args[0]) > 10) ufind = args[0];
+		if (args[1]) ufind = args[1];
+		ufind = ufind.replace('<@!', '');
+		ufind = ufind.replace('<@', '');
+		ufind = ufind.replace('>', '');
 	}
+
 	console.log(ufind);
 	let binddb = maindb.collection("userbind");
-	let query = { discordid: ufind };
-	binddb.find(query).toArray(function(err, res) {
+	let query = {discordid: ufind};
+	binddb.find(query).toArray(function (err, res) {
 		if (err) throw err;
 		if (res[0]) {
 			let uid = res[0].uid;
 			var options = new URL("http://ops.dgsrz.com/api/getuserinfo.php?apiKey=" + droidapikey + "&uid=" + uid);
-			var content = "";   
+			var content = "";
 
-			var req = http.get(options, function(res) {
+			var req = http.get(options, function (res) {
 				res.setEncoding("utf8");
 				res.on("data", function (chunk) {
 					content += chunk;
@@ -58,27 +68,32 @@ module.exports.run = (client, message, args, maindb) => {
 				res.on("end", function () {
 					var resarr = content.split('<br>');
 					var headerres = resarr[0].split(' ');
-					if (headerres[0] == 'FAILED') {message.channel.send("User not exist"); return;}
+					if (headerres[0] == 'FAILED') {
+						message.channel.send("User not exist");
+						return;
+					}
 					resarr.shift();
-					content = resarr.join("")
+					content = resarr.join("");
 					var obj = JSON.parse(content);
 					var name = headerres[2];
 					var entries = [];
 					var rplay = obj.recent;
-					for (var i = 0; i < 5; i++) {
+					for (var i = 5 * (page - 1); i < 5 + 5 * (page - 1); i++) {
 						if (!rplay[i]) break;
-						var date = new Date(rplay[i].date*1000);
+						var date = new Date(rplay[i].date * 1000);
 						date.setUTCHours(date.getUTCHours() + 8);
 						var entry = {
 							"name": client.emojis.get(rankEmote(rplay[i].mark)).toString() + " | " + rplay[i].filename + " " + modread(rplay[i].mode),
-							"value": rplay[i].score.toLocaleString() + ' / ' + rplay[i].combo + 'x / ' + parseFloat(rplay[i].accuracy)/1000 + '% / ' + rplay[i].miss + ' miss(es) \n `' + date.toUTCString() + '`'
-						}
+							"value": rplay[i].score.toLocaleString() + ' / ' + rplay[i].combo + 'x / ' + parseFloat(rplay[i].accuracy) / 1000 + '% / ' + rplay[i].miss + ' miss(es) \n `' + date.toUTCString() + '`'
+						};
 						entries.push(entry);
 					}
-					date.setUTCHours(date.getUTCHours() + 8)
-					if (!rplay[0]) {message.channel.send("This player haven't submitted any play"); return;}
+					if (!rplay[0]) {
+						message.channel.send("This player haven't submitted any play");
+						return;
+					}
 					const embed = {
-						"description": "Recent play for **" + name + "**",
+						"description": "Recent play for **" + name + " (Page " + page + ")**",
 						"color": 8102199,
 						"footer": {
 							"icon_url": "https://image.frl/p/yaa1nf94dho5f962.jpg",
@@ -86,13 +101,14 @@ module.exports.run = (client, message, args, maindb) => {
 						},
 						"fields": entries
 					};
-					
-					message.channel.send({ embed });
+
+					message.channel.send({embed});
 				})
 			})
 			req.end();
-		}
-		else { message.channel.send("The account is not binded, he/she/you need to use `&userbind <uid>` first. To get uid, use `&profilesearch <username>`") };
+		} else {
+			message.channel.send("The account is not binded, he/she/you need to use `&userbind <uid>` first. To get uid, use `&profilesearch <username>`")
+		};
 	});
 }
 

--- a/cmd/recent5me.js
+++ b/cmd/recent5me.js
@@ -32,21 +32,25 @@ function rankEmote(input) {
 }
 
 module.exports.run = (client, message, args, maindb) => {
-	let page = 1;
-	if (args[0]) page = parseInt(args[0]); //First argument will be page
-	if (isNaN(args[0]) || page <= 0 || page > 10) page = 1; //Detect out-of-range page input
 	let ufind = message.author.id;
-	
+	let page = 1;
 	/*Allows dynamic command format
-	If first argument is an integer with a value more than 10, it
-	treats the argument as user ID. Similarly, if it's a mention,
-	it will be treated as user ID as well.*/
+        If first argument is given and it is an integer with a value more than 10, it
+        treats the argument as user ID. Similarly, if it's a mention,
+        it will be treated as user ID as well.*/
 	if (args[0]) {
 		if (isNaN(args[0]) || parseInt(args[0]) > 10) ufind = args[0];
-		if (args[1]) ufind = args[1];
+		else if (parseInt(args[0]) <= 0) page = 1;
+		else page = parseInt(args[0]);
 		ufind = ufind.replace('<@!', '');
 		ufind = ufind.replace('<@', '');
 		ufind = ufind.replace('>', '');
+	}
+	/*The second argument will override previous assigned page if
+	it was given and the first statement was assigned as page*/
+	if (args[1]) {
+		if (isNaN(args[1]) || parseInt(args[1]) > 10 || parseInt(args[1]) <= 0) page = 1;
+		else page = parseInt(args[1]);
 	}
 
 	console.log(ufind);


### PR DESCRIPTION
Now supports up to 50 recent plays.

Changed command format to `&recent5me [page/discord user] [page]`.

The first argument (`page/discord user`) defines the page or user ID based on these conditions:
1. If the value entered is a NaN (Not-a-Number) value or a positive number that is more than 10, the bot will assign it as user ID. Mentions work too (will be assigned as user ID). Otherwise, it will be assigned as page number.
2. If the value entered is 0 or any negative number, the bot will assign it as page 1.

The second argument (`page`) defines the page, and it will override the previous `page` value if the first argument was assigned as page number. If the value entered is NaN, 0, or any negative number, the bot will return `1` as page number.

Example:
`&recent5me 3`
Returns page 3 of your recent plays.

`&recent5me 11`
The bot will assign `11` as user ID since 11 > 10.

`&recent5me 386742340968120321 5`
Returns page 5 of a user's recent plays with the user ID 386742340968120321.

`&recent5me <@mention> 6`
Returns page 6 of mentioned user's recent plays.

`&recent5me 2 <@mention>`
The bot will assign `1` as page number due to the second argument condition being fulfilled (also overrides previous assignment).