### PR TITLE
Update whitelistset.js

### DIFF
--- a/cmd/whitelistset.js
+++ b/cmd/whitelistset.js
@@ -90,9 +90,11 @@ function whitelistInfo(link_in, message, callback) {
             if (firstmapinfo.mode !=0) callback(0);
 
             for (i in mapinfo) {
-                mapid.push(mapinfo[i].beatmap_id);
-                hashid.push(mapinfo[i].file_md5);
-                diffstring.push(mapinfo[i].version);
+                if (mapinfo[i].mode == 0) {
+                    mapid.push(mapinfo[i].beatmap_id);
+                    hashid.push(mapinfo[i].file_md5);
+                    diffstring.push(mapinfo[i].version);
+                }
             }
             
             var listoutput = ""


### PR DESCRIPTION
Fix non-osu! standard beatmaps potentially getting whitelisted if the set containing the beatmap has standard difficulties