### PR TITLE
[IMPORTANT] Fix crash for role-related commands

### DIFF
--- a/mybot.js
+++ b/mybot.js
@@ -58,6 +58,7 @@ client.on("message", (message) => {
 	if (!message.content.startsWith(config.prefix)|| message.author.bot) return;
 	let cmd = client.commands.get(command.slice(config.prefix.length));
 	if (cmd) {
+		if (message.channel instanceof Discord.DMChannel) return message.channel.send("You cannot use commands in DMs");
 		cmd.run(client, message, args, maindb);
 	}
 });


### PR DESCRIPTION
A lot of commands rely on roles for it to work properly. Thus if those commands are used in DMs, the bot will crash due to `undefined` values.

Doing this will ensure that no role-related crashes can occur.