### PR TITLE
Restrict to verified members only

### DIFF
--- a/cmd/userbind.js
+++ b/cmd/userbind.js
@@ -1,84 +1,85 @@
+const Discord = require('discord.js');
 const http = require('http');
 const droidapikey = process.env.DROID_API_KEY;
 
 module.exports.run = (client, message, args, maindb) => {
+	if (message.channel instanceof Discord.DMChannel) return;
+	if (message.guild.id != "325667948905758730" && !message.member.roles.find(r => r.name === "Member")) return message.channel.send("You must be verified before binding your account!");
 	let uid = args[0];
 	if (!uid) return message.channel.send("Your uid please!");
-	if (isNaN(uid)) {message.channel.send("Invalid uid")}
-	else {
-		let binddb = maindb.collection("userbind");
-		let query = {discordid: message.author.id};
-		var options = {
-			host: "ops.dgsrz.com",
-			port: 80,
-			path: "/api/getuserinfo.php?apiKey=" + droidapikey + "&uid=" + uid
-		};
+	if (isNaN(uid)) return message.channel.send("Invalid uid");
+	let binddb = maindb.collection("userbind");
+	let query = {discordid: message.author.id};
+	var options = {
+		host: "ops.dgsrz.com",
+		port: 80,
+		path: "/api/getuserinfo.php?apiKey=" + droidapikey + "&uid=" + uid
+	};
 
-		var content = "";
+	var content = "";
 
-		var req = http.request(options, function (res) {
-			res.setEncoding("utf8");
-			res.on("data", function (chunk) {
-				content += chunk;
-			});
-			res.on("error", err => {
-				console.log(err);
-				return message.channel.send("Error: Unable to retrieve user data. Please try again!")
-			});
-			res.on("end", function () {
-				if (content.includes("<html>")) return message.channel.send("Invalid uid");
-				var headerres = content.split('<br>')[0].split(" ");
-				if (headerres[0] == 'FAILED') return message.channel.send("User doesn't exist");
-				let name = headerres[2];
-				let uid = headerres[1];
-				binddb.find({uid: uid}).toArray(function (err, res) {
-					if (err) throw err;
-					if (res[0]) return message.channel.send("Uid is already binded");
-					var bind = {
+	var req = http.request(options, function (res) {
+		res.setEncoding("utf8");
+		res.on("data", function (chunk) {
+			content += chunk;
+		});
+		res.on("error", err => {
+			console.log(err);
+			return message.channel.send("Error: Unable to retrieve user data. Please try again!")
+		});
+		res.on("end", function () {
+			if (content.includes("<html>")) return message.channel.send("Invalid uid");
+			var headerres = content.split('<br>')[0].split(" ");
+			if (headerres[0] == 'FAILED') return message.channel.send("User doesn't exist");
+			let name = headerres[2];
+			let uid = headerres[1];
+			binddb.find({uid: uid}).toArray(function (err, res) {
+				if (err) throw err;
+				if (res[0]) return message.channel.send("Uid is already binded");
+				var bind = {
+					discordid: message.author.id,
+					uid: uid,
+					username: name,
+					pptotal: 0,
+					playc: 0,
+					pp: []
+				};
+				var updatebind = {
+					$set: {
 						discordid: message.author.id,
 						uid: uid,
-						username: name,
-						pptotal: 0,
-						playc: 0,
-						pp: []
-					};
-					var updatebind = {
-						$set: {
-							discordid: message.author.id,
-							uid: uid,
-							username: name
-						}
-					};
-					binddb.find(query).toArray(function (err, res) {
-						if (err) {
-							console.log(err);
-							return message.channel.send("Error: Empty database response. Please try again!")
-						}
-						if (!res[0]) {
-							binddb.insertOne(bind, function (err, res) {
-								if (err) {
-									console.log(err);
-									return message.channel.send("Error: Empty database response. Please try again!")
-								}
-								console.log("bind added");
-								message.channel.send("Haii <3, binded <@" + message.author.id + "> to uid " + uid);
-							})
-						} else {
-							binddb.updateOne(query, updatebind, function (err, res) {
-								if (err) {
-									console.log(err);
-									return message.channel.send("Error: Empty database response. Please try again!")
-								}
-								console.log("bind updated");
-								message.channel.send("Haii <3, binded <@" + message.author.id + "> to uid " + uid);
-							})
-						}
-					})
+						username: name
+					}
+				};
+				binddb.find(query).toArray(function (err, res) {
+					if (err) {
+						console.log(err);
+						return message.channel.send("Error: Empty database response. Please try again!")
+					}
+					if (!res[0]) {
+						binddb.insertOne(bind, function (err, res) {
+							if (err) {
+								console.log(err);
+								return message.channel.send("Error: Empty database response. Please try again!")
+							}
+							console.log("bind added");
+							message.channel.send("Haii <3, binded <@" + message.author.id + "> to uid " + uid);
+						})
+					} else {
+						binddb.updateOne(query, updatebind, function (err, res) {
+							if (err) {
+								console.log(err);
+								return message.channel.send("Error: Empty database response. Please try again!")
+							}
+							console.log("bind updated");
+							message.channel.send("Haii <3, binded <@" + message.author.id + "> to uid " + uid);
+						})
+					}
 				})
 			})
-		});
-		req.end()
-	}
+		})
+	});
+	req.end()
 };
 
 module.exports.help = {


### PR DESCRIPTION
Leaving userbind open to public will impose risks as unverified users can bind to any random account or anyone can bind accounts through DMs. Therefore, it should not be allowed, especially considering the fact that we've disabled duplicate binds.

Since Elaina is not in any servers other than secret base and international server, only the secret base needs to be excluded from check, which is why `message.guild.id != "325667948905758730"` is present in it.